### PR TITLE
Couple of grammatical fixes

### DIFF
--- a/2023/01/08/weakening_on_linear_f/index.html
+++ b/2023/01/08/weakening_on_linear_f/index.html
@@ -7,18 +7,18 @@
   
   <title>A tale of sum types on Linear F | A tale about computers</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="description" content="The Linear F is a system similar to System F◦, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
+  <meta name="description" content="The Linear F is a system similar to System F°, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
 <meta name="keywords" content="ocaml,typer,theory,linear">
 <meta property="og:type" content="article">
 <meta property="og:title" content="A tale of sum types on Linear F">
 <meta property="og:url" content="https://eduardorfs.github.io/2023/01/08/weakening_on_linear_f/index.html">
 <meta property="og:site_name" content="A tale about computers">
-<meta property="og:description" content="The Linear F is a system similar to System F◦, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
+<meta property="og:description" content="The Linear F is a system similar to System F°, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
 <meta property="og:locale" content="en">
 <meta property="og:updated_time" content="2023-01-08T18:20:37.121Z">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="A tale of sum types on Linear F">
-<meta name="twitter:description" content="The Linear F is a system similar to System F◦, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
+<meta name="twitter:description" content="The Linear F is a system similar to System F°, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism. TLDRTo encode sum types, weakening">
   
     <link rel="alternate" href="/atom.xml" title="A tale about computers" type="application/atom+xml">
   
@@ -90,21 +90,21 @@
     
     <div class="article-entry" itemprop="articleBody">
       
-        <p>The <a href="https://github.com/EduardoRFS/linear-f/" target="_blank" rel="noopener">Linear F</a> is a system similar to <a href="https://www.cis.upenn.edu/~stevez/papers/MZZ10.pdf" target="_blank" rel="noopener">System F◦</a>, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism.</p>
-<h2 id="TLDR"><a href="#TLDR" class="headerlink" title="TLDR"></a>TLDR</h2><p>To encode sum types, weakening is required. By carrying the garbage around in a monad you can easily model do weakening on Linear F. As such you can encode sum types on Linear F. Proof <a href="https://github.com/EduardoRFS/linear-f/blob/main/examples/weak.linf#L34" target="_blank" rel="noopener">weak.linf</a></p>
+        <p>The <a href="https://github.com/EduardoRFS/linear-f/" target="_blank" rel="noopener">Linear F</a> is a system similar to <a href="https://www.cis.upenn.edu/~stevez/papers/MZZ10.pdf" target="_blank" rel="noopener">System F°</a>, but where the traditional type kind was removed, so it is a pure linear lambda calculus with first-class polymorphism.</p>
+<h2 id="TLDR"><a href="#TLDR" class="headerlink" title="TLDR"></a>TLDR</h2><p>To encode sum types, weakening is required. By carrying the garbage around in a monad you can easily model weakening on Linear F. As such you can encode sum types on Linear F. Proof <a href="https://github.com/EduardoRFS/linear-f/blob/main/examples/weak.linf#L34" target="_blank" rel="noopener">weak.linf</a></p>
 <h2 id="Context"><a href="#Context" class="headerlink" title="Context"></a>Context</h2><p>I’ve been playing with linear type systems for a while, currently I hold the opinion that some form of linear calculus is probably the right solution for a modern functional programming language.</p>
-<p>As such I’ve been trying to show that you can do everything in a pure linear calculus. By doing {church,scott}-encoding of every interesting primitive present in real languages, sadly many of the traditional encodings rely on weakening, which is not directly available on a linear calculus due to that, the traditional wisdom is that sum types are not possible in a pure linear calculus.</p>
+<p>As such I’ve been trying to show that you can do everything in a pure linear calculus. By doing {church,scott}-encoding of every interesting primitive present in real languages, sadly many of the traditional encodings rely on weakening, which is not directly available on a linear calculus. Due to that, the traditional wisdom is that sum types are not possible in a pure linear calculus.</p>
 <h2 id="Explicit-Weakening"><a href="#Explicit-Weakening" class="headerlink" title="Explicit Weakening"></a>Explicit Weakening</h2><p>My hypothesis is that weakening can always be explicitly encoded in a linear system by carrying everything discard explicitly as a parameter.</p>
 <p>The main idea is that any function that relies on weakening can return all the discarded elements together with its output as a multiplicative products aka a pair.</p>
 <h3 id="Naive-Weakening-Encoding"><a href="#Naive-Weakening-Encoding" class="headerlink" title="Naive Weakening Encoding"></a>Naive Weakening Encoding</h3><p>The simplest encoding possible is to literally just return a pair, so to describe the affine term <code>x =&gt; y =&gt; x</code> would be written as <code>x =&gt; y =&gt; (x, y)</code>, the convention here is that the second element of the pair is just garbage and as such should be ignored.</p>
 <h3 id="Nicer-Weakening-Encoding"><a href="#Nicer-Weakening-Encoding" class="headerlink" title="Nicer Weakening Encoding"></a>Nicer Weakening Encoding</h3><p>A type encoding is possible for the garbage in the presence of existential types, the garbage bag can have the type of <code>Garbage === ∃x. x</code>, which can be encoded in Linear F. This makes so that a function to <a href="https://github.com/EduardoRFS/linear-f/blob/main/examples/weak.linf#L10" target="_blank" rel="noopener">collect garbage</a> can be done.</p>
-<h3 id="An-even-nicer-weakening-encoding"><a href="#An-even-nicer-weakening-encoding" class="headerlink" title="An even nicer weakening encoding"></a>An even nicer weakening encoding</h3><p>A nicer encoding can be done by making a monad for weakening, this makes so that handling garbage is implicit in the monadic context. <code>Weak A === Garbage -&gt; (A, Garbage)</code>, so any function doing weakening can have the type <code>A -&gt; Weak B</code>.</p>
-<h3 id="The-perfect-weakening-encoding"><a href="#The-perfect-weakening-encoding" class="headerlink" title="The perfect weakening encoding"></a>The perfect weakening encoding</h3><p>While monadic weakening is nice enough to actually use it, an even better one would be an encoding based on algebraic effects, such that the function <code>weak : ∀A. A -[Weak]&gt; ()</code> can be used to explicit weaken anything, such a function wills simply pack it as <code>Garbage</code> and call the effect handler, which can then decide what to do with such piece of data.</p>
+<h3 id="An-even-nicer-weakening-encoding"><a href="#An-even-nicer-weakening-encoding" class="headerlink" title="An even nicer weakening encoding"></a>An even nicer weakening encoding</h3><p>A nicer encoding can be done by making a monad for weakening, this makes so that handling garbage is implicit in the monadic context <code>Weak A === Garbage -&gt; (A, Garbage)</code>, so any function doing weakening can have the type <code>A -&gt; Weak B</code>.</p>
+<h3 id="The-perfect-weakening-encoding"><a href="#The-perfect-weakening-encoding" class="headerlink" title="The perfect weakening encoding"></a>The perfect weakening encoding</h3><p>While monadic weakening is nice enough to actually use it, an even better one would be an encoding based on algebraic effects, such that the function <code>weak : ∀A. A -[Weak]&gt; ()</code> can be used to explicit weaken anything, such a function will simply pack it as <code>Garbage</code> and call the effect handler, which can then decide what to do with such piece of data.</p>
 <p>This could be combined with first class support of the language as an implicit effect so that it behaves exactly like an affine system.</p>
 <h2 id="Back-to-Sum-Types"><a href="#Back-to-Sum-Types" class="headerlink" title="Back to Sum Types"></a>Back to Sum Types</h2><p>Many of the traditional church encodings for data rely on weakening, such as booleans and sum types, ex : <code>true === x =&gt; y =&gt; x</code>. As such those encodings seems to not work in a purely linear setting, but they can be done in an affine setting.</p>
 <p>And as shown above, weakening can be done on the Linear System F, which is contrary to some beliefs:</p>
 <blockquote>
-<p>[MZZ10] - we cannot encode linear sums in System F◦ as presented so far</p>
+<p>[MZZ10] - we cannot encode linear sums in System F° as presented so far</p>
 </blockquote>
 <blockquote>
 <p><a href="https://oleg.fi/gists/posts/2019-06-26-linear-church-encodings.html#encoding-of-with" target="_blank" rel="noopener">Church encoding of linear types</a> - Unfortunate, but known fact. So, we cannot (at least obviously) simulate A &amp; B using something else.</p>


### PR DESCRIPTION
Looks like "do" was left over from an edit. Missing full stop, extra full stop.

I also chose to replace F◦ with F°, I think the exponent position is traditionally used.